### PR TITLE
Performance improvement for getting the data out of SparseMatrix

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -83,11 +83,20 @@ export class SparseMatrix {
     }
   }
 
-  getAll(): { value: number; row: number; col: number }[] {
-    let rowColValues: Entry[] = [];
+  getAll(ordered = true): { value: number; row: number; col: number }[] {
+    const rowColValues: Entry[] = [];
     this.entries.forEach((value) => {
       rowColValues.push(value);
     });
+    if (ordered) { // Ordering the result isn't required for processing but it does make it easier to write tests
+      rowColValues.sort((a, b) => {
+        if (a.row === b.row) {
+          return a.col - b.col;
+        } else {
+          return a.row - b.row;
+        }
+      });
+    }
     return rowColValues;
   }
 

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -44,8 +44,8 @@ export class SparseMatrix {
     this.nRows = dims[0];
     this.nCols = dims[1];
     for (let i = 0; i < values.length; i++) {
-      var row = rows[i];
-      var col = cols[i];
+      const row = rows[i];
+      const col = cols[i];
       this.checkDims(row, col);
       const key = this.makeKey(row, col);
       this.entries.set(key, { value: values[i], row, col });

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -19,15 +19,13 @@
 
 import * as utils from './utils';
 
+type Entry = { value: number; row: number; col: number };
+
 /**
  * Internal 2-dimensional sparse matrix class
  */
 export class SparseMatrix {
-  private rows: number[];
-  private cols: number[];
-  private values: number[];
-
-  private entries = new Map<string, number>();
+  private entries = new Map<string, Entry>();
 
   readonly nRows: number = 0;
   readonly nCols: number = 0;
@@ -38,19 +36,20 @@ export class SparseMatrix {
     values: number[],
     dims: number[]
   ) {
-    // TODO: Assert that rows / cols / vals are the same length.
-    this.rows = [...rows];
-    this.cols = [...cols];
-    this.values = [...values];
-
-    for (let i = 0; i < values.length; i++) {
-      const key = this.makeKey(this.rows[i], this.cols[i]);
-      this.entries.set(key, i);
+    if ((rows.length !== cols.length) || (rows.length !== values.length)) {
+      throw new Error("rows, cols and values arrays must all have the same length");
     }
 
     // TODO: Assert that dims are legit.
     this.nRows = dims[0];
     this.nCols = dims[1];
+    for (let i = 0; i < values.length; i++) {
+      var row = rows[i];
+      var col = cols[i];
+      this.checkDims(row, col);
+      const key = this.makeKey(row, col);
+      this.entries.set(key, { value: values[i], row, col });
+    }
   }
 
   private makeKey(row: number, col: number): string {
@@ -60,7 +59,7 @@ export class SparseMatrix {
   private checkDims(row: number, col: number) {
     const withinBounds = row < this.nRows && col < this.nCols;
     if (!withinBounds) {
-      throw new Error('array index out of bounds');
+      throw new Error('row and/or col specified outside of matrix dimensions');
     }
   }
 
@@ -68,13 +67,9 @@ export class SparseMatrix {
     this.checkDims(row, col);
     const key = this.makeKey(row, col);
     if (!this.entries.has(key)) {
-      this.rows.push(row);
-      this.cols.push(col);
-      this.values.push(value);
-      this.entries.set(key, this.values.length - 1);
+      this.entries.set(key, { value, row, col });
     } else {
-      const index = this.entries.get(key)!;
-      this.values[index] = value;
+      this.entries.get(key)!.value = value;
     }
   }
 
@@ -82,11 +77,18 @@ export class SparseMatrix {
     this.checkDims(row, col);
     const key = this.makeKey(row, col);
     if (this.entries.has(key)) {
-      const index = this.entries.get(key)!;
-      return this.values[index];
+      return this.entries.get(key)!.value;
     } else {
       return defaultValue;
     }
+  }
+
+  getAll(): { value: number; row: number; col: number }[] {
+    let rowColValues: Entry[] = [];
+    this.entries.forEach((value) => {
+      rowColValues.push(value);
+    });
+    return rowColValues;
   }
 
   getDims(): number[] {
@@ -94,30 +96,28 @@ export class SparseMatrix {
   }
 
   getRows(): number[] {
-    return [...this.rows];
+    return Array.from(this.entries, ([key, value]) => value.row);
   }
 
   getCols(): number[] {
-    return [...this.cols];
+    return Array.from(this.entries, ([key, value]) => value.col);
   }
 
   getValues(): number[] {
-    return [...this.values];
+    return Array.from(this.entries, ([key, value]) => value.value);
   }
 
   forEach(fn: (value: number, row: number, col: number) => void): void {
-    for (let i = 0; i < this.values.length; i++) {
-      fn(this.values[i], this.rows[i], this.cols[i]);
-    }
+    this.entries.forEach((value) => fn(value.value, value.row, value.col));
   }
 
   map(fn: (value: number, row: number, col: number) => number): SparseMatrix {
     let vals: number[] = [];
-    for (let i = 0; i < this.values.length; i++) {
-      vals.push(fn(this.values[i], this.rows[i], this.cols[i]));
-    }
+    this.entries.forEach((value) => {
+      vals.push(fn(value.value, value.row, value.col));
+    });
     const dims = [this.nRows, this.nCols];
-    return new SparseMatrix(this.rows, this.cols, vals, dims);
+    return new SparseMatrix(this.getRows(), this.getCols(), vals, dims);
   }
 
   toArray() {
@@ -125,9 +125,9 @@ export class SparseMatrix {
     const output = rows.map(() => {
       return utils.zeros(this.nCols);
     });
-    for (let i = 0; i < this.values.length; i++) {
-      output[this.rows[i]][this.cols[i]] = this.values[i];
-    }
+    this.entries.forEach((value) => {
+      output[value.row][value.col] = value.value;
+    });
     return output;
   }
 }
@@ -338,7 +338,6 @@ function elementWise(
  * search logic depends on this data format.
  */
 export function getCSR(x: SparseMatrix) {
-  type Entry = { value: number; row: number; col: number };
   const entries: Entry[] = [];
 
   x.forEach((value, row, col) => {

--- a/src/umap.ts
+++ b/src/umap.ts
@@ -811,12 +811,12 @@ export class UMAP {
     const tail: number[] = [];
     const rowColValues = graph.getAll();
     for (let i = 0; i < rowColValues.length; i++) {
-        const entry = rowColValues[i];
-        if (entry.value) {
-            weights.push(entry.value);
-            tail.push(entry.row);
-            head.push(entry.col);
-        }
+      const entry = rowColValues[i];
+      if (entry.value) {
+        weights.push(entry.value);
+        tail.push(entry.row);
+        head.push(entry.col);
+      }
     }    
     const epochsPerSample = this.makeEpochsPerSample(weights, nEpochs);
 

--- a/src/umap.ts
+++ b/src/umap.ts
@@ -809,16 +809,15 @@ export class UMAP {
     const weights: number[] = [];
     const head: number[] = [];
     const tail: number[] = [];
-    for (let i = 0; i < graph.nRows; i++) {
-      for (let j = 0; j < graph.nCols; j++) {
-        const value = graph.get(i, j);
-        if (value) {
-          weights.push(value);
-          tail.push(i);
-          head.push(j);
+    var rowColValues = graph.getAll();
+    for (let i = 0; i < rowColValues.length; i++) {
+        const entry = rowColValues[i];
+        if (entry.value) {
+            weights.push(entry.value);
+            tail.push(entry.row);
+            head.push(entry.col);
         }
-      }
-    }
+    }    
     const epochsPerSample = this.makeEpochsPerSample(weights, nEpochs);
 
     return { head, tail, epochsPerSample };

--- a/src/umap.ts
+++ b/src/umap.ts
@@ -809,7 +809,7 @@ export class UMAP {
     const weights: number[] = [];
     const head: number[] = [];
     const tail: number[] = [];
-    var rowColValues = graph.getAll();
+    const rowColValues = graph.getAll();
     for (let i = 0; i < rowColValues.length; i++) {
         const entry = rowColValues[i];
         if (entry.value) {

--- a/test/matrix.test.ts
+++ b/test/matrix.test.ts
@@ -58,6 +58,21 @@ describe('sparse matrix', () => {
     expect(matrix.get(0, 1)).toEqual(9);
   });
 
+  test('sparse matrix has getAll method', () => {
+    const rows = [0, 0, 1, 1];
+    const cols = [0, 1, 0, 1];
+    const vals = [1, 2, 3, 4];
+    const dims = [2, 2];
+    const matrix = new SparseMatrix(rows, cols, vals, dims);
+
+    expect(matrix.getAll()).toEqual([
+      { row: 0, col: 0, value: 1 },
+      { row: 0, col: 1, value: 2 },
+      { row: 1, col: 0, value: 3 },
+      { row: 1, col: 1, value: 4 }
+    ]);
+  });
+
   test('sparse matrix has toArray method', () => {
     const rows = [0, 0, 1, 1];
     const cols = [0, 1, 0, 1];

--- a/test/matrix.test.ts
+++ b/test/matrix.test.ts
@@ -36,7 +36,7 @@ describe('sparse matrix', () => {
   test('constructs a sparse matrix from rows/cols/vals ', () => {
     const rows = [0, 0, 1, 1];
     const cols = [0, 1, 0, 1];
-    const vals = [1, 2];
+    const vals = [1, 2, 3, 4];
     const dims = [2, 2];
     const matrix = new SparseMatrix(rows, cols, vals, dims);
     expect(matrix.getRows()).toEqual(rows);


### PR DESCRIPTION
I was experimenting with different sizes of data (based upon resized-to-10x10px MNIST images) and I trying to see if there were any easy performance wins because if I tried to process 10,000 vectors then the calculations would complete in under a minute but 25,000 would take over five minutes and 50,000 would take over 25 minutes.

Looking into where the time was spent, a lot of it was in umap's initializeSimplicialSetEmbedding method when it was getting all of the non-zero values from SparseMatrix instances - in fact, with larger data sets, this account for the majority of the time spent processing!

In this pull request, I've added a "getAll" method to the SparseMatrix so that this work may be done more cheaply. I've changed the internal structure away from separate rows, cols and values array with a Map lookup into those arrays - instead there is now a Map who value contains each row, col, value tuple - which made it easier to make this change. I also think that it's more easily understood this way (though I may be biased! :)

Now, 10,000 items with 100 dimensions takes 18s to process on my computer, 25,000 take 53s and 50,000 take just over 2 minutes.