### PR TITLE
Fix incorrect sort method in getCSR

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -36,8 +36,10 @@ export class SparseMatrix {
     values: number[],
     dims: number[]
   ) {
-    if ((rows.length !== cols.length) || (rows.length !== values.length)) {
-      throw new Error("rows, cols and values arrays must all have the same length");
+    if (rows.length !== cols.length || rows.length !== values.length) {
+      throw new Error(
+        'rows, cols and values arrays must all have the same length'
+      );
     }
 
     // TODO: Assert that dims are legit.
@@ -85,10 +87,11 @@ export class SparseMatrix {
 
   getAll(ordered = true): { value: number; row: number; col: number }[] {
     const rowColValues: Entry[] = [];
-    this.entries.forEach((value) => {
+    this.entries.forEach(value => {
       rowColValues.push(value);
     });
-    if (ordered) { // Ordering the result isn't required for processing but it does make it easier to write tests
+    if (ordered) {
+      // Ordering the result isn't required for processing but it does make it easier to write tests
       rowColValues.sort((a, b) => {
         if (a.row === b.row) {
           return a.col - b.col;
@@ -117,12 +120,12 @@ export class SparseMatrix {
   }
 
   forEach(fn: (value: number, row: number, col: number) => void): void {
-    this.entries.forEach((value) => fn(value.value, value.row, value.col));
+    this.entries.forEach(value => fn(value.value, value.row, value.col));
   }
 
   map(fn: (value: number, row: number, col: number) => number): SparseMatrix {
     let vals: number[] = [];
-    this.entries.forEach((value) => {
+    this.entries.forEach(value => {
       vals.push(fn(value.value, value.row, value.col));
     });
     const dims = [this.nRows, this.nCols];
@@ -134,7 +137,7 @@ export class SparseMatrix {
     const output = rows.map(() => {
       return utils.zeros(this.nCols);
     });
-    this.entries.forEach((value) => {
+    this.entries.forEach(value => {
       output[value.row][value.col] = value.value;
     });
     return output;
@@ -357,7 +360,7 @@ export function getCSR(x: SparseMatrix) {
     if (a.row === b.row) {
       return a.col - b.col;
     } else {
-      return a.row - b.col;
+      return a.row - b.row;
     }
   });
 

--- a/test/matrix.test.ts
+++ b/test/matrix.test.ts
@@ -69,7 +69,7 @@ describe('sparse matrix', () => {
       { row: 0, col: 0, value: 1 },
       { row: 0, col: 1, value: 2 },
       { row: 1, col: 0, value: 3 },
-      { row: 1, col: 1, value: 4 }
+      { row: 1, col: 1, value: 4 },
     ]);
   });
 
@@ -223,8 +223,8 @@ describe('normalize method', () => {
 
   test('getCSR function', () => {
     const { indices, values, indptr } = getCSR(A);
-    expect(indices).toEqual([0, 1, 2, 0, 0, 1, 2, 1, 2]);
-    expect(values).toEqual([1, 2, 3, 7, 4, 5, 6, 8, 9]);
-    expect(indptr).toEqual([0, 3, 4, 7]);
+    expect(indices).toEqual([0, 1, 2, 0, 1, 2, 0, 1, 2]);
+    expect(values).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(indptr).toEqual([0, 3, 6]);
   });
 });


### PR DESCRIPTION
Per https://github.com/PAIR-code/umap-js/issues/22, fixes a bug in the `getCSR` function - the implementation now correctly matches the scipy version.