### PR TITLE
Iterate over array with `of` instead of `in`

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -217,7 +217,7 @@ function euclideanRandomProjectionSplit(
   // Populate the arrays with indices according to which side they fell on
   nLeft = 0;
   nRight = 0;
-  for (let i in utils.range(side.length)) {
+  for (let i of utils.range(side.length)) {
     if (side[i] === 0) {
       indicesLeft[nLeft] = indices[i];
       nLeft += 1;


### PR DESCRIPTION
This fixes a place where an array was iterated over using the `in` operator. While this works in many situations, it causes unexpected behavior (crashes later on) when a library is loaded that extends the Object or Array prototypes.

(It took me an embarrassingly long time to figure out why UMAP was crashing in my Ember application.)