### PR TITLE
Fix bugs with tree hyperplanes and infinite loop

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -242,7 +242,7 @@ function flattenTree(tree: RandomProjectionTreeNode, leafSize: number) {
   // TODO: Verify that sparse code is not relevant...
   const hyperplanes = utils
     .range(nNodes)
-    .map(() => utils.zeros(tree.hyperplane!.length));
+    .map(() => utils.zeros(tree.hyperplane ? tree.hyperplane.length : 0));
 
   const offsets = utils.zeros(nNodes);
   const children = utils.range(nNodes).map(() => [-1, -1]);

--- a/src/umap.ts
+++ b/src/umap.ts
@@ -411,7 +411,8 @@ export class UMAP {
       throw new Error('No data has been fit.');
     }
 
-    const nNeighbors = Math.floor(this.nNeighbors * this.transformQueueSize);
+    let nNeighbors = Math.floor(this.nNeighbors * this.transformQueueSize);
+    nNeighbors = Math.min(rawData.length, nNeighbors);
     const init = nnDescent.initializeSearch(
       this.rpForest,
       rawData,
@@ -821,7 +822,7 @@ export class UMAP {
         tail.push(entry.row);
         head.push(entry.col);
       }
-    }    
+    }
     const epochsPerSample = this.makeEpochsPerSample(weights, nEpochs);
 
     return { head, tail, epochsPerSample };


### PR DESCRIPTION
https://github.com/PAIR-code/umap-js/issues/30
https://github.com/PAIR-code/umap-js/issues/31

Fixes two errors: incorrectly assuming that `tree.hyperplane` would always exist (it doesn't, in some cases) and initializing search with more potential neighbors than data points causing an infinite loop...